### PR TITLE
Dockerfiles updated to reduce image sizes

### DIFF
--- a/alpine-elasticsearch/Dockerfile
+++ b/alpine-elasticsearch/Dockerfile
@@ -5,12 +5,13 @@ ENV ES_VERSION 2.2.0
 # Install
 RUN apk update && apk upgrade
 RUN apk add --update curl
-RUN curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.tar.gz
-RUN tar -zxvf elasticsearch-$ES_VERSION.tar.gz && rm elasticsearch-$ES_VERSION.tar.gz
-RUN mv /elasticsearch-$ES_VERSION /elasticsearch
+RUN curl -L -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.tar.gz \
+    && tar -zxvf elasticsearch-$ES_VERSION.tar.gz \
+    && rm elasticsearch-$ES_VERSION.tar.gz \
+    && mv /elasticsearch-$ES_VERSION /elasticsearch \
+    && rm $(find /elasticsearch | egrep "\.(exe|bat)")
 
 # Clean up
-RUN rm $(find /elasticsearch | egrep "\.(exe|bat)")
 RUN apk del curl && rm -rfv /var/cache/apk/* /tmp/* /var/tmp/*
 
 # Copy

--- a/alpine-elasticsearch/Dockerfile
+++ b/alpine-elasticsearch/Dockerfile
@@ -3,10 +3,13 @@ FROM oberthur/docker-alpine-java
 ENV ES_VERSION 2.2.0
 
 # Install
+RUN apk update && apk upgrade
 RUN apk add --update curl
 RUN curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.tar.gz
-RUN tar -zxvf elasticsearch-$ES_VERSION.tar.gz
+RUN tar -zxvf elasticsearch-$ES_VERSION.tar.gz && rm elasticsearch-$ES_VERSION.tar.gz
 RUN mv /elasticsearch-$ES_VERSION /elasticsearch
+
+# Clean up
 RUN rm $(find /elasticsearch | egrep "\.(exe|bat)")
 RUN apk del curl && rm -rfv /var/cache/apk/* /tmp/* /var/tmp/*
 

--- a/alpine-javabase/Dockerfile
+++ b/alpine-javabase/Dockerfile
@@ -1,14 +1,16 @@
 FROM oberthur/docker-alpine-java
 
-RUN apk add --update git wget
+ENV MAVEN_VERSION 3.3.9
 
-RUN wget http://ftp.fau.de/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
-RUN tar -zxvf apache-maven-3.3.9-bin.tar.gz
-RUN rm apache-maven-3.3.9-bin.tar.gz
-RUN mv apache-maven-3.3.9 /usr/lib/mvn
+# Install
+RUN apk update && apk upgrade
+RUN apk add --update curl
+RUN curl -L -O http://ftp.fau.de/apache/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz
+RUN tar -zxvf apache-maven-$MAVEN_VERSION-bin.tar.gz && rm apache-maven-$MAVEN_VERSION-bin.tar.gz
+RUN mv apache-maven-$MAVEN_VERSION /usr/lib/mvn
 
-RUN apk del wget && \
-	rm /var/cache/apk/*
+# Clean up
+RUN apk del curl && rm -rfv /var/cache/apk/* /tmp/* /var/tmp/*
 
 ENV M2_HOME=/usr/lib/mvn
 ENV M2=$M2_HOME/bin

--- a/alpine-javabase/Dockerfile
+++ b/alpine-javabase/Dockerfile
@@ -5,9 +5,10 @@ ENV MAVEN_VERSION 3.3.9
 # Install
 RUN apk update && apk upgrade
 RUN apk add --update curl
-RUN curl -L -O http://ftp.fau.de/apache/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz
-RUN tar -zxvf apache-maven-$MAVEN_VERSION-bin.tar.gz && rm apache-maven-$MAVEN_VERSION-bin.tar.gz
-RUN mv apache-maven-$MAVEN_VERSION /usr/lib/mvn
+RUN curl -L -O http://ftp.fau.de/apache/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    && tar -zxvf apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    && rm apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    && mv apache-maven-$MAVEN_VERSION /usr/lib/mvn
 
 # Clean up
 RUN apk del curl && rm -rfv /var/cache/apk/* /tmp/* /var/tmp/*

--- a/alpine-javabase/Makefile
+++ b/alpine-javabase/Makefile
@@ -1,0 +1,4 @@
+default: build
+
+build:
+	docker build -t docker-registry-container.efset.org/efset/javabase .


### PR DESCRIPTION
Reduced image sizes of elasticsearch and javabase
alpine-javabase -> 209.3 MB to 190.7 MB
alpine-elasticsearch -> 276.4 MB to 208.5 MB
